### PR TITLE
fix: 수익률 비교 차트 종목별 시간 동기화 적용

### DIFF
--- a/src/app/api/compare/data/route.ts
+++ b/src/app/api/compare/data/route.ts
@@ -134,13 +134,13 @@ export async function GET(request: NextRequest) {
       };
     });
 
-    // 시간축 정렬 (선택적 - 현재 비활성화)
-    // const aligned = alignTimeSeries(normalizedDatasets);
-    // aligned.forEach((values, code) => {
-    //   if (items[code]) {
-    //     items[code].values = values;
-    //   }
-    // });
+    // 시간축 정렬 - Forward Fill 방식으로 누락 데이터 채움
+    const aligned = alignTimeSeries(normalizedDatasets);
+    aligned.forEach((values, code) => {
+      if (items[code]) {
+        items[code].values = values;
+      }
+    });
 
     const response: ComparisonData = {
       period,


### PR DESCRIPTION
## Summary
- 수익률 비교 차트에서 `alignTimeSeries()` 함수 활성화
- Forward Fill 방식으로 누락 데이터 채워 모든 종목이 동일 시간축 공유
- 종목별 시작점이 달라도 정확한 수익률 비교 가능

## Changes
- `src/app/api/compare/data/route.ts`: 주석처리된 시간축 정렬 로직 활성화

## Test plan
- [ ] 수익률 비교 차트에서 여러 종목 추가 후 시간축 동기화 확인
- [ ] 거래정지 등으로 데이터 누락된 종목의 Forward Fill 동작 확인

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)