### PR TITLE
feat: 수익률 비교 차트 선차트/봉차트 전환 기능

### DIFF
--- a/src/app/(main)/compare/page.tsx
+++ b/src/app/(main)/compare/page.tsx
@@ -9,18 +9,20 @@ import {
   ComparisonChart,
   ComparisonLegend,
   ComparisonPeriodSelector,
+  ComparisonChartTypeSelector,
   ComparisonSymbolSearch,
   ComparisonSetManager,
 } from '@/components/compare';
 import { useComparison } from '@/hooks/useComparison';
 import { useComparisonSets } from '@/hooks/useComparisonSets';
-import type { ComparePeriod, ComparisonItem, ComparisonItemType, ComparisonSet } from '@/types/comparison';
+import type { ComparePeriod, ComparisonChartType, ComparisonItem, ComparisonItemType, ComparisonSet } from '@/types/comparison';
 import { getComparisonColor, isIndexCode, SUPPORTED_INDICES, toComparePeriod } from '@/types/comparison';
 
 export default function ComparePage() {
   // 상태
   const [items, setItems] = useState<ComparisonItem[]>([]);
   const [period, setPeriod] = useState<ComparePeriod>('6M');
+  const [chartType, setChartType] = useState<ComparisonChartType>('line');
   const [currentSetId, setCurrentSetId] = useState<string | undefined>();
   const [searchOpen, setSearchOpen] = useState(false);
 
@@ -211,12 +213,19 @@ export default function ComparePage() {
               )}
             </div>
 
-            {/* 기간 선택 */}
-            <ComparisonPeriodSelector
-              value={period}
-              onChange={handlePeriodChange}
-              disabled={isDataLoading}
-            />
+            {/* 기간 및 차트 타입 선택 */}
+            <div className="flex items-center gap-2">
+              <ComparisonPeriodSelector
+                value={period}
+                onChange={handlePeriodChange}
+                disabled={isDataLoading}
+              />
+              <ComparisonChartTypeSelector
+                value={chartType}
+                onChange={setChartType}
+                disabled={isDataLoading}
+              />
+            </div>
           </div>
 
           {/* 추가된 종목 목록 (범례) */}
@@ -270,6 +279,7 @@ export default function ComparePage() {
             <ComparisonChart
               data={comparisonData ?? null}
               orderedCodes={visibleSymbols}
+              chartType={chartType}
               height={400}
               className="min-h-[400px]"
             />

--- a/src/app/api/compare/data/route.ts
+++ b/src/app/api/compare/data/route.ts
@@ -3,6 +3,7 @@ import { stockProvider } from '@/lib/api/provider-factory';
 import { normalizeSymbol } from '@/lib/validation';
 import {
   normalizeToReturn,
+  normalizeOHLCToReturn,
   calculateCurrentReturn,
   alignTimeSeries,
   getStartDateForPeriod,
@@ -117,12 +118,14 @@ export async function GET(request: NextRequest) {
           name: result.name,
           type: result.type,
           values: [],
+          ohlcValues: [],
           currentReturn: 0,
         };
         return;
       }
 
       const normalized = normalizeToReturn(result.ohlcv, period);
+      const ohlcNormalized = normalizeOHLCToReturn(result.ohlcv, period);
       const currentReturn = calculateCurrentReturn(result.ohlcv, period);
 
       normalizedDatasets.set(result.code, normalized);
@@ -130,6 +133,7 @@ export async function GET(request: NextRequest) {
         name: result.name,
         type: result.type,
         values: normalized,
+        ohlcValues: ohlcNormalized,
         currentReturn,
       };
     });

--- a/src/components/compare/ComparisonChart.tsx
+++ b/src/components/compare/ComparisonChart.tsx
@@ -6,12 +6,18 @@ import {
   IChartApi,
   ISeriesApi,
   LineData,
+  CandlestickData,
   ColorType,
   CrosshairMode,
   Time,
   LineStyle,
 } from 'lightweight-charts';
-import type { ComparisonData, NormalizedDataPoint } from '@/types/comparison';
+import type {
+  ComparisonData,
+  NormalizedDataPoint,
+  NormalizedOHLCPoint,
+  ComparisonChartType,
+} from '@/types/comparison';
 import { getComparisonColor } from '@/types/comparison';
 import { formatReturn } from '@/lib/comparison/normalize';
 
@@ -20,18 +26,58 @@ export interface ComparisonChartProps {
   data: ComparisonData | null;
   /** 종목 코드 순서 (색상 매칭용) */
   orderedCodes: string[];
+  /** 차트 타입 (기본값: 'line') */
+  chartType?: ComparisonChartType;
   /** 차트 높이 (기본값: 400) */
   height?: number;
   /** 클래스명 */
   className?: string;
 }
 
-/** 정규화된 데이터를 Lightweight Charts 형식으로 변환 */
+/** 정규화된 데이터를 Lightweight Charts 선차트 형식으로 변환 */
 function toLineData(data: NormalizedDataPoint[]): LineData<Time>[] {
   return data.map((d) => ({
     time: d.time as Time,
     value: d.value,
   }));
+}
+
+/** 정규화된 OHLC 데이터를 Lightweight Charts 캔들스틱 형식으로 변환 */
+function toCandleData(data: NormalizedOHLCPoint[]): CandlestickData<Time>[] {
+  return data.map((d) => ({
+    time: d.time as Time,
+    open: d.open,
+    high: d.high,
+    low: d.low,
+    close: d.close,
+  }));
+}
+
+/** HEX 색상의 밝기 조정 */
+function adjustColorBrightness(hex: string, factor: number): string {
+  // HEX to RGB
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+
+  // 밝기 조정
+  const adjust = (c: number) => Math.min(255, Math.max(0, Math.round(c * factor)));
+
+  // RGB to HEX
+  const toHex = (c: number) => c.toString(16).padStart(2, '0');
+  return `#${toHex(adjust(r))}${toHex(adjust(g))}${toHex(adjust(b))}`;
+}
+
+/** 종목 색상 기반으로 상승/하락 색상 생성 */
+function getCandleColors(baseColor: string) {
+  return {
+    upColor: adjustColorBrightness(baseColor, 1.2),      // 밝게
+    downColor: adjustColorBrightness(baseColor, 0.6),    // 어둡게
+    borderUpColor: baseColor,
+    borderDownColor: adjustColorBrightness(baseColor, 0.5),
+    wickUpColor: baseColor,
+    wickDownColor: adjustColorBrightness(baseColor, 0.5),
+  };
 }
 
 /**
@@ -42,12 +88,13 @@ function toLineData(data: NormalizedDataPoint[]): LineData<Time>[] {
 export const ComparisonChart = memo(function ComparisonChart({
   data,
   orderedCodes,
+  chartType = 'line',
   height = 400,
   className = '',
 }: ComparisonChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
-  const seriesRefs = useRef<Map<string, ISeriesApi<'Line'>>>(new Map());
+  const seriesRefs = useRef<Map<string, ISeriesApi<'Line' | 'Candlestick'>>>(new Map());
   const baselineSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
 
   // 차트 초기화
@@ -172,31 +219,48 @@ export const ComparisonChart = memo(function ComparisonChart({
     });
     seriesRefs.current.clear();
 
-    // orderedCodes 순서대로 라인 시리즈 새로 생성 (색상 순서 보장)
+    // orderedCodes 순서대로 시리즈 새로 생성 (색상 순서 보장)
     orderedCodes.forEach((code, index) => {
       const item = items[code];
       if (!item) return; // 데이터가 아직 로드되지 않은 경우
 
       const color = getComparisonColor(index);
-      const lineData = toLineData(item.values);
 
-      // 새 시리즈 생성
-      const series = chart.addLineSeries({
-        color,
-        lineWidth: 2,
-        crosshairMarkerVisible: true,
-        crosshairMarkerRadius: 4,
-        priceFormat: {
-          type: 'custom',
-          formatter: (value: number) => formatReturn(value),
-        },
-        lastValueVisible: true,
-        priceLineVisible: false,
-      });
-      seriesRefs.current.set(code, series);
+      if (chartType === 'candle' && item.ohlcValues && item.ohlcValues.length > 0) {
+        // 봉차트 시리즈 생성
+        const candleColors = getCandleColors(color);
+        const candleData = toCandleData(item.ohlcValues);
 
-      // 데이터 설정
-      series.setData(lineData);
+        const series = chart.addCandlestickSeries({
+          ...candleColors,
+          priceFormat: {
+            type: 'custom',
+            formatter: (value: number) => formatReturn(value),
+          },
+          lastValueVisible: true,
+          priceLineVisible: false,
+        });
+        seriesRefs.current.set(code, series);
+        series.setData(candleData);
+      } else {
+        // 선차트 시리즈 생성
+        const lineData = toLineData(item.values);
+
+        const series = chart.addLineSeries({
+          color,
+          lineWidth: 2,
+          crosshairMarkerVisible: true,
+          crosshairMarkerRadius: 4,
+          priceFormat: {
+            type: 'custom',
+            formatter: (value: number) => formatReturn(value),
+          },
+          lastValueVisible: true,
+          priceLineVisible: false,
+        });
+        seriesRefs.current.set(code, series);
+        series.setData(lineData);
+      }
     });
 
     // 기준선 시리즈 데이터를 실제 데이터 범위에 맞게 업데이트
@@ -216,7 +280,7 @@ export const ComparisonChart = memo(function ComparisonChart({
     // 차트 범위 자동 조정
     chart.timeScale().fitContent();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, orderedCodesKey]); // orderedCodesKey는 orderedCodes의 문자열 표현
+  }, [data, orderedCodesKey, chartType]); // orderedCodesKey는 orderedCodes의 문자열 표현
 
   return (
     <div className={`relative ${className}`}>

--- a/src/components/compare/ComparisonChartTypeSelector.tsx
+++ b/src/components/compare/ComparisonChartTypeSelector.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import type { ComparisonChartType } from '@/types/comparison';
+import { CHART_TYPE_OPTIONS } from '@/types/comparison';
+import { cn } from '@/lib/utils';
+
+export interface ComparisonChartTypeSelectorProps {
+  /** 현재 선택된 차트 타입 */
+  value: ComparisonChartType;
+  /** 차트 타입 변경 콜백 */
+  onChange: (type: ComparisonChartType) => void;
+  /** 비활성화 여부 */
+  disabled?: boolean;
+  /** 클래스명 */
+  className?: string;
+}
+
+/**
+ * 비교 차트 타입 선택 컴포넌트
+ *
+ * Line, Candle 버튼 그룹
+ */
+export function ComparisonChartTypeSelector({
+  value,
+  onChange,
+  disabled = false,
+  className,
+}: ComparisonChartTypeSelectorProps) {
+  return (
+    <div className={cn('inline-flex rounded-lg bg-muted p-1', className)}>
+      {CHART_TYPE_OPTIONS.map((option) => (
+        <Button
+          key={option.value}
+          variant="ghost"
+          size="sm"
+          disabled={disabled}
+          className={cn(
+            'h-8 px-3 text-sm font-medium transition-colors',
+            value === option.value
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+export default ComparisonChartTypeSelector;

--- a/src/components/compare/index.ts
+++ b/src/components/compare/index.ts
@@ -1,4 +1,5 @@
 export { ComparisonChart } from './ComparisonChart';
+export { ComparisonChartTypeSelector } from './ComparisonChartTypeSelector';
 export { ComparisonLegend } from './ComparisonLegend';
 export { ComparisonPeriodSelector } from './ComparisonPeriodSelector';
 export { ComparisonSymbolSearch } from './ComparisonSymbolSearch';

--- a/src/lib/comparison/normalize.ts
+++ b/src/lib/comparison/normalize.ts
@@ -3,7 +3,7 @@
  */
 
 import type { OHLCV } from '@/types';
-import type { NormalizedDataPoint, ComparePeriod } from '@/types/comparison';
+import type { NormalizedDataPoint, NormalizedOHLCPoint, ComparePeriod } from '@/types/comparison';
 import { PERIOD_LIMITS } from '@/types/comparison';
 
 /**
@@ -35,6 +35,40 @@ export function normalizeToReturn(
     // Lightweight Charts는 초 단위 timestamp 사용
     time: Math.floor(d.time / 1000),
     value: ((d.close - basePrice) / basePrice) * 100,
+  }));
+}
+
+/**
+ * OHLCV 데이터를 OHLC 수익률(%)로 정규화 (봉차트용)
+ * 첫 번째 데이터의 종가를 기준으로 OHLC 모두 수익률 계산
+ *
+ * @param data - OHLCV 데이터 배열 (시간순 정렬)
+ * @param period - 기간 (데이터 개수 제한용)
+ * @returns 정규화된 OHLC 데이터 포인트 배열
+ */
+export function normalizeOHLCToReturn(
+  data: OHLCV[],
+  period: ComparePeriod
+): NormalizedOHLCPoint[] {
+  if (data.length === 0) return [];
+
+  // 기간에 맞게 데이터 자르기 (최근 N개)
+  const limit = PERIOD_LIMITS[period];
+  const slicedData = data.slice(-limit);
+
+  if (slicedData.length === 0) return [];
+
+  // 첫 번째 데이터의 종가를 기준으로 수익률 계산
+  const basePrice = slicedData[0].close;
+
+  if (basePrice === 0) return [];
+
+  return slicedData.map((d) => ({
+    time: Math.floor(d.time / 1000),
+    open: ((d.open - basePrice) / basePrice) * 100,
+    high: ((d.high - basePrice) / basePrice) * 100,
+    low: ((d.low - basePrice) / basePrice) * 100,
+    close: ((d.close - basePrice) / basePrice) * 100,
   }));
 }
 

--- a/src/types/comparison.ts
+++ b/src/types/comparison.ts
@@ -5,6 +5,9 @@
 // 비교 기간
 export type ComparePeriod = '1M' | '3M' | '6M' | '1Y' | '2Y';
 
+// 차트 타입
+export type ComparisonChartType = 'line' | 'candle';
+
 // 비교 아이템 타입
 export type ComparisonItemType = 'stock' | 'index';
 
@@ -17,17 +20,27 @@ export interface ComparisonItem {
   visible: boolean;   // 차트 표시 여부
 }
 
-// 정규화된 데이터 포인트
+// 정규화된 데이터 포인트 (선차트용)
 export interface NormalizedDataPoint {
   time: number;       // Unix timestamp (초)
   value: number;      // 수익률 (%, 시작점=0)
+}
+
+// 정규화된 OHLC 데이터 포인트 (봉차트용)
+export interface NormalizedOHLCPoint {
+  time: number;       // Unix timestamp (초)
+  open: number;       // 시가 수익률 (%)
+  high: number;       // 고가 수익률 (%)
+  low: number;        // 저가 수익률 (%)
+  close: number;      // 종가 수익률 (%)
 }
 
 // 비교 데이터 응답의 개별 아이템
 export interface ComparisonDataItem {
   name: string;
   type: ComparisonItemType;
-  values: NormalizedDataPoint[];
+  values: NormalizedDataPoint[];       // 선차트용
+  ohlcValues?: NormalizedOHLCPoint[];  // 봉차트용
   currentReturn: number; // 현재 수익률
 }
 
@@ -87,6 +100,12 @@ export const PERIOD_OPTIONS: { value: ComparePeriod; label: string }[] = [
   { value: '6M', label: '6개월' },
   { value: '1Y', label: '1년' },
   { value: '2Y', label: '2년' },
+];
+
+// 차트 타입 옵션 (UI용)
+export const CHART_TYPE_OPTIONS: { value: ComparisonChartType; label: string }[] = [
+  { value: 'line', label: 'Line' },
+  { value: 'candle', label: 'Candle' },
 ];
 
 // 차트 색상 팔레트 (최대 10개)


### PR DESCRIPTION
## Summary
- 수익률 비교 차트에서 선차트(Line)와 봉차트(Candle) 두 가지 타입 지원
- 차트 타입 선택 UI 추가 (기간 선택 옆에 배치)
- 종목별 고유 색상으로 봉차트 상승/하락을 밝기로 구분

## Changes
- `src/types/comparison.ts`: `ComparisonChartType`, `NormalizedOHLCPoint` 타입 추가
- `src/lib/comparison/normalize.ts`: `normalizeOHLCToReturn()` 함수 추가
- `src/app/api/compare/data/route.ts`: API 응답에 `ohlcValues` 필드 추가
- `src/components/compare/ComparisonChartTypeSelector.tsx`: 차트 타입 선택 컴포넌트 생성
- `src/components/compare/ComparisonChart.tsx`: 봉차트 렌더링 로직 추가
- `src/app/(main)/compare/page.tsx`: 차트 타입 상태 및 UI 통합

## Test plan
- [ ] 선차트/봉차트 전환 동작 확인
- [ ] 봉차트에서 종목별 색상 구분 확인
- [ ] 봉차트에서 상승/하락 밝기 구분 확인

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)